### PR TITLE
Add link path match style

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ The `default-class` list will be applied if the urls don't match, and the `curre
 
 The naming of these attributes aligns with the comments found in the Tailwind UI templates and the `-class` suffix allows the attributes to automatically work with [Headwind](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind).
 
+The matching method can be either `Full` (default) which ensures the link path and current path are the same, or `Base` which ensures the link path starts with, or is the same as, the current path.
+
+> ℹ️ Query string values are not used for either method of matching.
+
 ```html
 <a
   asp-area="" asp-controller="Home" asp-action="Index"
   class="px-3 py-2 text-sm font-medium rounded-md"
   default-class="text-gray-300 hover:bg-gray-700 hover:text-white"
   current-class="text-white bg-gray-900"
+  match="Base"
 >
   Home
 </a>

--- a/src/LinkTagHelper.cs
+++ b/src/LinkTagHelper.cs
@@ -8,18 +8,22 @@ using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-[HtmlTargetElement("a")]
+[HtmlTargetElement("a", Attributes = CurrentClassAttributeName)]
+[HtmlTargetElement("a", Attributes = DefaultClassAttributeName)]
 public class LinkTagHelper : TagHelper
 {
+    private const string CurrentClassAttributeName = "current-class";
+    private const string DefaultClassAttributeName = "default-class";
+
     private static readonly char[] SpaceChars = { '\u0020', '\u0009', '\u000A', '\u000C', '\u000D' };
 
     // Puts us after the built-in link tag helper that resolves urls
     public override int Order => 1001;
 
-    [HtmlAttributeName("current-class")]
+    [HtmlAttributeName(CurrentClassAttributeName)]
     public string? CurrentClass { get; set; }
 
-    [HtmlAttributeName("default-class")]
+    [HtmlAttributeName(DefaultClassAttributeName)]
     public string? DefaultClass { get; set; }
 
     [HtmlAttributeNotBound]

--- a/src/LinkTagHelper.cs
+++ b/src/LinkTagHelper.cs
@@ -1,57 +1,56 @@
-namespace Tailwind.Css.TagHelpers
+namespace Tailwind.Css.TagHelpers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+[HtmlTargetElement("a")]
+public class LinkTagHelper : TagHelper
 {
-    using System.Diagnostics.CodeAnalysis;
-    using System.Text.Encodings.Web;
+    private static readonly char[] SpaceChars = { '\u0020', '\u0009', '\u000A', '\u000C', '\u000D' };
 
-    using Microsoft.AspNetCore.Mvc.Rendering;
-    using Microsoft.AspNetCore.Mvc.TagHelpers;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Razor.TagHelpers;
+    // Puts us after the built-in link tag helper that resolves urls
+    public override int Order => 1001;
 
-    [HtmlTargetElement("a")]
-    public class LinkTagHelper : TagHelper
+    [HtmlAttributeName("current-class")]
+    public string? CurrentClass { get; set; }
+
+    [HtmlAttributeName("default-class")]
+    public string? DefaultClass { get; set; }
+
+    [HtmlAttributeNotBound]
+    [ViewContext]
+    [NotNull]
+    public ViewContext? ViewContext { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        private static readonly char[] SpaceChars = { '\u0020', '\u0009', '\u000A', '\u000C', '\u000D' };
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (output is null) throw new ArgumentNullException(nameof(output));
 
-        // Puts us after the built-in link tag helper that resolves urls
-        public override int Order => 1001;
+        var target = ViewContext.HttpContext.Request.Path;
 
-        [HtmlAttributeName("current-class")]
-        public string? CurrentClass { get; set; }
+        var href = output.Attributes["href"]?.Value as string;
 
-        [HtmlAttributeName("default-class")]
-        public string? DefaultClass { get; set; }
-
-        [HtmlAttributeNotBound]
-        [ViewContext]
-        [NotNull]
-        public ViewContext? ViewContext { get; set; }
-
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        string[]? classList;
+        if (string.Equals(href, target, StringComparison.OrdinalIgnoreCase))
         {
-            if (context is null) throw new ArgumentNullException(nameof(context));
-            if (output is null) throw new ArgumentNullException(nameof(output));
+            classList = CurrentClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
+        }
+        else
+        {
+            classList = DefaultClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
+        }
 
-            var target = ViewContext.HttpContext.Request.Path;
-
-            var href = output.Attributes["href"]?.Value as string;
-
-            string[]? classList;
-            if (string.Equals(href, target, StringComparison.OrdinalIgnoreCase))
+        if (classList?.Length > 0)
+        {
+            foreach (var className in classList)
             {
-                classList = CurrentClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
-            }
-            else
-            {
-                classList = DefaultClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
-            }
-
-            if (classList?.Length > 0)
-            {
-                foreach (var className in classList)
-                {
-                    output.AddClass(className, HtmlEncoder.Default);
-                }
+                output.AddClass(className, HtmlEncoder.Default);
             }
         }
     }

--- a/src/PathMatchStyle.cs
+++ b/src/PathMatchStyle.cs
@@ -1,0 +1,7 @@
+﻿namespace Tailwind.Css.TagHelpers;
+
+public enum PathMatchStyle
+{
+    Full = 0,
+    Base = 1,
+}

--- a/test/LinkTagHelperTests.cs
+++ b/test/LinkTagHelperTests.cs
@@ -1,166 +1,165 @@
-namespace Tailwind.Css.TagHelpers
+namespace Tailwind.Css.TagHelpers;
+
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+
+public class LinkTagHelperTests
 {
-    using Microsoft.AspNetCore.Html;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Abstractions;
-    using Microsoft.AspNetCore.Mvc.ModelBinding;
-    using Microsoft.AspNetCore.Mvc.Rendering;
-    using Microsoft.AspNetCore.Mvc.ViewEngines;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Razor.TagHelpers;
-    using Microsoft.AspNetCore.Routing;
-
-    public class LinkTagHelperTests
+    [Fact]
+    public void Should_do_nothing_if_options_are_not_set()
     {
-        [Fact]
-        public void Should_do_nothing_if_options_are_not_set()
-        {
-            // Given
-            var context = MakeTagHelperContext(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                });
-            var output = MakeTagHelperOutput(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                    { "href", "/foo" },
-                });
-            var viewContext = MakeViewContext("/foo");
-
-            var helper = new LinkTagHelper
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList
             {
-                ViewContext = viewContext,
-            };
-
-            // When
-            helper.Process(context, output);
-
-            // Then
-            output.Attributes["class"].ShouldNotBeNull();
-
-            var classList = output.Attributes["class"].Value as string;
-            classList.ShouldNotBeNull();
-            classList.ShouldBe("text-black");
-        }
-
-        [Fact]
-        public void Should_add_default_classes_when_not_the_current_url()
-        {
-            // Given
-            var context = MakeTagHelperContext(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                });
-            var output = MakeTagHelperOutput(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                    { "href", "/foo" },
-                });
-            var viewContext = MakeViewContext("/bar");
-
-            var helper = new LinkTagHelper
+                { "class", "text-black" },
+            });
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList
             {
-                CurrentClass = "bg-orange no-underline",
-                DefaultClass = "bg-white underline",
-                ViewContext = viewContext,
-            };
+                { "class", "text-black" },
+                { "href", "/foo" },
+            });
+        var viewContext = MakeViewContext("/foo");
 
-            // When
-            helper.Process(context, output);
-
-            // Then
-            output.Attributes["class"].ShouldNotBeNull();
-
-            var classList = output.Attributes["class"].Value as HtmlString;
-            classList.ShouldNotBeNull();
-            classList.Value.ShouldBe("text-black bg-white underline");
-        }
-
-        [Fact]
-        public void Should_add_current_classes_when_the_current_url()
+        var helper = new LinkTagHelper
         {
-            // Given
-            var context = MakeTagHelperContext(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                });
-            var output = MakeTagHelperOutput(
-                tagName: "a",
-                new TagHelperAttributeList
-                {
-                    { "class", "text-black" },
-                    { "href", "/bar" },
-                });
-            var viewContext = MakeViewContext("/bar");
+            ViewContext = viewContext,
+        };
 
-            var helper = new LinkTagHelper
+        // When
+        helper.Process(context, output);
+
+        // Then
+        output.Attributes["class"].ShouldNotBeNull();
+
+        var classList = output.Attributes["class"].Value as string;
+        classList.ShouldNotBeNull();
+        classList.ShouldBe("text-black");
+    }
+
+    [Fact]
+    public void Should_add_default_classes_when_not_the_current_url()
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList
             {
-                CurrentClass = "bg-orange no-underline",
-                DefaultClass = "bg-white underline",
-                ViewContext = viewContext,
-            };
-
-            // When
-            helper.Process(context, output);
-
-            // Then
-            output.Attributes["class"].ShouldNotBeNull();
-
-            var classList = output.Attributes["class"].Value as HtmlString;
-            classList.ShouldNotBeNull();
-            classList.Value.ShouldBe("text-black bg-orange no-underline");
-        }
-
-        private static ViewContext MakeViewContext(string? requestPath = null)
-        {
-            var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
-            if (requestPath is not null)
+                { "class", "text-black" },
+            });
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList
             {
-                actionContext.HttpContext.Request.Path = new PathString(requestPath);
-            }
+                { "class", "text-black" },
+                { "href", "/foo" },
+            });
+        var viewContext = MakeViewContext("/bar");
 
-            var metadataProvider = new EmptyModelMetadataProvider();
-            var viewData = new ViewDataDictionary(metadataProvider, new ModelStateDictionary());
-
-            return new ViewContext(
-                actionContext,
-                A.Fake<IView>(),
-                viewData,
-                A.Fake<ITempDataDictionary>(),
-                TextWriter.Null,
-                new HtmlHelperOptions());
-        }
-
-        private static TagHelperContext MakeTagHelperContext(string tagName, TagHelperAttributeList? attributes = null)
+        var helper = new LinkTagHelper
         {
-            attributes ??= new TagHelperAttributeList();
+            CurrentClass = "bg-orange no-underline",
+            DefaultClass = "bg-white underline",
+            ViewContext = viewContext,
+        };
 
-            return new TagHelperContext(
-                tagName,
-                allAttributes: attributes,
-                items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"));
-        }
+        // When
+        helper.Process(context, output);
 
-        private static TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList? attributes = null)
+        // Then
+        output.Attributes["class"].ShouldNotBeNull();
+
+        var classList = output.Attributes["class"].Value as HtmlString;
+        classList.ShouldNotBeNull();
+        classList.Value.ShouldBe("text-black bg-white underline");
+    }
+
+    [Fact]
+    public void Should_add_current_classes_when_the_current_url()
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList
+            {
+                { "class", "text-black" },
+            });
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList
+            {
+                { "class", "text-black" },
+                { "href", "/bar" },
+            });
+        var viewContext = MakeViewContext("/bar");
+
+        var helper = new LinkTagHelper
         {
-            attributes ??= new TagHelperAttributeList();
+            CurrentClass = "bg-orange no-underline",
+            DefaultClass = "bg-white underline",
+            ViewContext = viewContext,
+        };
 
-            return new TagHelperOutput(
-                tagName,
-                attributes,
-                getChildContentAsync: (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+        // When
+        helper.Process(context, output);
+
+        // Then
+        output.Attributes["class"].ShouldNotBeNull();
+
+        var classList = output.Attributes["class"].Value as HtmlString;
+        classList.ShouldNotBeNull();
+        classList.Value.ShouldBe("text-black bg-orange no-underline");
+    }
+
+    private static ViewContext MakeViewContext(string? requestPath = null)
+    {
+        var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+        if (requestPath is not null)
+        {
+            actionContext.HttpContext.Request.Path = new PathString(requestPath);
         }
+
+        var metadataProvider = new EmptyModelMetadataProvider();
+        var viewData = new ViewDataDictionary(metadataProvider, new ModelStateDictionary());
+
+        return new ViewContext(
+            actionContext,
+            A.Fake<IView>(),
+            viewData,
+            A.Fake<ITempDataDictionary>(),
+            TextWriter.Null,
+            new HtmlHelperOptions());
+    }
+
+    private static TagHelperContext MakeTagHelperContext(string tagName, TagHelperAttributeList? attributes = null)
+    {
+        attributes ??= new TagHelperAttributeList();
+
+        return new TagHelperContext(
+            tagName,
+            allAttributes: attributes,
+            items: new Dictionary<object, object>(),
+            uniqueId: Guid.NewGuid().ToString("N"));
+    }
+
+    private static TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList? attributes = null)
+    {
+        attributes ??= new TagHelperAttributeList();
+
+        return new TagHelperOutput(
+            tagName,
+            attributes,
+            getChildContentAsync: (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
     }
 }


### PR DESCRIPTION
Adds path match options for `Full` (the prior functionality) and `Base`. [`PathString`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.pathstring) is used to do the matching so the trailing segment needs to be an exact match meaning `/foo` isn't the base path for `/foobar` but it is the base path for `/foo/bar`. Matching is also done using [`StringComparison.OrdinalIgnoreCase`](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparer.ordinalignorecase) at the moment.