### PR TITLE
Add tag helper to include an aria-current attribute on href match

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD013": false,
+  "MD024": false,
   "MD033": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-- Updated `LinkTagHelper` so any immediate child elements that also have `default-class` or `current-class` attributes will also have their class lists merged.
+### Added
+
+- Added `LinkAriaCurrentStateTagHelper` which will add an [`aria-current="*"`](https://www.w3.org/TR/wai-aria-1.1/#aria-current) attribute to links that are processed by `LinkTagHelper` and include an `aria-current-state="*"` attribute.
+
+### Updated
+
+- Immediate child elements of `LinkTagHelper` that have `default-class` or `current-class` attributes will also have their class lists merged.
 - Switched from [actions/setup-dotnet](https://github.com/actions/setup-dotnet) to [xt0rted/setup-dotnet](https://github.com/xt0rted/setup-dotnet).
 
 ## [0.1.0](https://github.com/xt0rted/tailwindcss-tag-helpers/releases/tag/v0.1.0) - 2021-12-19

--- a/README.md
+++ b/README.md
@@ -42,11 +42,45 @@ In your `appsettings.json` add:
 
 ## Settings
 
-Name | Default Value | Description
+Name | Default value | Description
 :-- | :-- | :--
 `IncludeComments` | `false` | Add html comments before the target tag with base, current, and default classes to help make development/debugging easier.
 
 ## Usage
+
+### LinkAriaCurrentStateTagHelper
+
+Adds the [`aria-current="*"`](https://www.w3.org/TR/wai-aria-1.1/#aria-current) attribute to links that are processed by the `LinkTagHelper` and include an `aria-current-state="*"` attribute.
+
+```html
+<a
+  asp-area="" asp-controller="Home" asp-action="Index"
+  class="px-3 py-2 text-sm font-medium rounded-md"
+  default-class="text-gray-300 hover:bg-gray-700 hover:text-white"
+  current-class="text-white bg-gray-900"
+  aria-current-state="Page"
+>
+  Home
+</a>
+```
+
+Will output:
+
+```html
+<a
+  href="/"
+  class="px-3 py-2 text-sm font-medium rounded-md text-white bg-gray-900"
+  aria-current="page"
+>
+  Home
+</a>
+```
+
+#### Attributes
+
+Name | Value | Description
+:-- | :-- | :--
+`aria-current-state` | `True`, `Page` (default), `Step` | The value to use for the `aria-current` attribute.
 
 ### LinkTagHelper
 
@@ -80,3 +114,27 @@ The matching method can be either `Full` (default) which ensures the link path a
   </span>
 </a>
 ```
+
+Will output:
+
+```html
+<a
+  href="/"
+  class="px-3 py-2 text-sm font-medium rounded-md text-white bg-gray-900"
+>
+  Home
+  <span
+    class="ml-auto inline-block py-0.5 px-3 text-xs rounded-full bg-gray-50"
+  >
+    5
+  </span>
+</a>
+```
+
+#### Attributes
+
+Name | Value | Description
+:-- | :-- | :--
+`current-class` | `string` | The css classes to apply if the link matches the current url.
+`default-class` | `string` | The css classes to apply if the link doesn't match the current url.
+`match` | `Full` (default) or `Base` | The method to use when matching the link to the current url.

--- a/sample/Pages/Index.cshtml
+++ b/sample/Pages/Index.cshtml
@@ -6,5 +6,5 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a class="text-sky-600" href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a class="text-sky-600" href="https://docs.microsoft.com/aspnet/core" aria-current-state="Page">building Web apps with ASP.NET Core</a>.</p>
 </div>

--- a/sample/Pages/Shared/_Layout.cshtml
+++ b/sample/Pages/Shared/_Layout.cshtml
@@ -14,6 +14,7 @@
         class="group flex items-center px-3 py-2 text-sm font-medium rounded-md"
         default-class="text-gray-600 hover:bg-gray-50 hover:text-gray-900"
         current-class="bg-gray-200 text-gray-900"
+        aria-current-state="Page"
       >
         <heroicon-outline
           icon="Home"
@@ -29,6 +30,7 @@
         class="group flex items-center px-3 py-2 text-sm font-medium rounded-md"
         default-class="text-gray-600 hover:bg-gray-50 hover:text-gray-900"
         current-class="bg-gray-200 text-gray-900"
+        aria-current-state="Page"
       >
         <heroicon-outline
           icon="EyeOff"
@@ -52,6 +54,7 @@
         class="group flex items-center px-3 py-2 text-sm font-medium rounded-md"
         default-class="text-gray-600 hover:bg-gray-50 hover:text-gray-900"
         current-class="bg-gray-200 text-gray-900"
+        aria-current-state="Page"
       >
         <heroicon-outline
           icon="ExclamationCircle"

--- a/src/LinkAriaCurrentState.cs
+++ b/src/LinkAriaCurrentState.cs
@@ -1,0 +1,16 @@
+namespace Tailwind.Css.TagHelpers;
+
+public enum LinkAriaCurrentState
+{
+    True = 0,
+
+    /// <summary>
+    /// A <c>page</c> token used to indicate a link within a set of pagination links, where the link is visually styled to represent the currently-displayed page.
+    /// </summary>
+    Page = 1,
+
+    /// <summary>
+    /// A <c>step</c> token used to indicate a link within a step indicator for a step-based process, where the link is visually styled to represent the current step.
+    /// </summary>
+    Step = 2,
+}

--- a/src/LinkAriaCurrentStateTagHelper.cs
+++ b/src/LinkAriaCurrentStateTagHelper.cs
@@ -1,0 +1,65 @@
+namespace Tailwind.Css.TagHelpers;
+
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+[HtmlTargetElement("a", Attributes = AriaCurrentMatchAttributeName)]
+public class LinkAriaCurrentStateTagHelper : TagHelper
+{
+    private const string AriaCurrentMatchAttributeName = "aria-current-state";
+
+    private readonly ILogger<LinkAriaCurrentStateTagHelper> _logger;
+    private readonly TagOptions _settings;
+
+    public LinkAriaCurrentStateTagHelper(
+        ILogger<LinkAriaCurrentStateTagHelper> logger,
+        IOptions<TagOptions> settings)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    // Puts us after the LinkTagHelper
+    public override int Order => 1002;
+
+    [HtmlAttributeName(AriaCurrentMatchAttributeName)]
+    public LinkAriaCurrentState State { get; set; } = LinkAriaCurrentState.Page;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+
+        if (!context.Items.TryGetValue(typeof(LinkContext), out var ctx) || ctx is not LinkContext linkContext)
+        {
+            var message = $"Parent context not found for element using {AriaCurrentMatchAttributeName}=\"{State}\" tag helper";
+
+            _logger.LogError(message);
+
+            if (_settings.IncludeComments)
+            {
+                output.PreElement.AppendHtml("<!-- ⚠️ ");
+                output.PreElement.AppendHtml(message);
+                output.PreElement.AppendHtmlLine(" -->");
+            }
+
+            return;
+        }
+
+        if (linkContext.IsMatch)
+        {
+            output.Attributes.Add("aria-current", StateValue(State));
+        }
+    }
+
+    private static string StateValue(LinkAriaCurrentState value)
+        => value switch
+        {
+            LinkAriaCurrentState.True => "true",
+            LinkAriaCurrentState.Page => "page",
+            LinkAriaCurrentState.Step => "step",
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unsuported aria-current state"),
+        };
+}

--- a/test/LinkAriaCurrentStateTagHelperTests.cs
+++ b/test/LinkAriaCurrentStateTagHelperTests.cs
@@ -1,0 +1,132 @@
+namespace Tailwind.Css.TagHelpers;
+
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class LinkAriaCurrentStateTagHelperTests : TagHelperTestBase
+{
+    [Fact]
+    public void Should_not_throw_when_no_link_context_set()
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList());
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList());
+
+        var logger = A.Dummy<ILogger<LinkAriaCurrentStateTagHelper>>();
+        var options = Options.Create(new TagOptions());
+        var helper = new LinkAriaCurrentStateTagHelper(logger, options);
+
+        // When
+        var result = () => helper.Process(context, output);
+
+        // Then
+        result.ShouldNotThrow();
+    }
+
+    [Theory]
+    [InlineData(LinkAriaCurrentState.True, "true")]
+    [InlineData(LinkAriaCurrentState.Page, "page")]
+    [InlineData(LinkAriaCurrentState.Step, "step")]
+    public void Should_set_attribute_when_enabled(LinkAriaCurrentState state, string attributeValue)
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList());
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList());
+
+        AddLinkContext(context, isMatch: true);
+
+        var logger = A.Dummy<ILogger<LinkAriaCurrentStateTagHelper>>();
+        var options = Options.Create(
+            new TagOptions
+            {
+                IncludeComments = true,
+            });
+        var helper = new LinkAriaCurrentStateTagHelper(logger, options)
+        {
+            State = state,
+        };
+
+        // When
+        helper.Process(context, output);
+
+        // Then
+        var result = output.Attributes.FirstOrDefault(a => a.Name == "aria-current");
+        result.ShouldNotBeNull();
+
+        result.Value.ShouldBe(attributeValue);
+    }
+
+    [Fact]
+    public void Should_not_emit_comments_when_setting_is_disabled()
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList());
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList());
+
+        var logger = A.Dummy<ILogger<LinkAriaCurrentStateTagHelper>>();
+        var options = Options.Create(
+            new TagOptions
+            {
+                IncludeComments = false,
+            });
+        var helper = new LinkAriaCurrentStateTagHelper(logger, options);
+
+        // When
+        helper.Process(context, output);
+
+        // Then
+        output.PreElement.GetContent().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_emit_comments_when_setting_is_enabled()
+    {
+        // Given
+        var context = MakeTagHelperContext(
+            tagName: "a",
+            new TagHelperAttributeList());
+        var output = MakeTagHelperOutput(
+            tagName: "a",
+            new TagHelperAttributeList());
+
+        var logger = A.Dummy<ILogger<LinkAriaCurrentStateTagHelper>>();
+        var options = Options.Create(
+            new TagOptions
+            {
+                IncludeComments = true,
+            });
+        var helper = new LinkAriaCurrentStateTagHelper(logger, options);
+
+        // When
+        helper.Process(context, output);
+
+        // Then
+        output.PreElement.GetContent().ShouldBe(
+            """
+            <!-- ⚠️ Parent context not found for element using aria-current-state="Page" tag helper -->
+
+            """);
+    }
+
+    private static void AddLinkContext(TagHelperContext context, bool isMatch)
+        => context.Items.Add(
+            typeof(LinkContext),
+            new LinkContext
+            {
+                IsMatch = isMatch,
+                MatchStyle = PathMatchStyle.Full,
+            });
+}


### PR DESCRIPTION
This builds on #156 and adds `AriaCurrentLinkStateTagHelper` which, when used with the `LinkTagHelper`, uses the `aria-current-state` attribute to determine if an [`aria-current="*"`](https://www.w3.org/TR/wai-aria-1.1/#aria-current) attribute should be added to the target element.

The only valid states I'm aware of here are `true`, `page` (default), and `step` so that's all that's supported.