### PR TITLE
Use a more robust class extraction method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Base class extraction correctly handles `IHtmlContent` attribute types
+
 ## [0.2.0](https://github.com/xt0rted/tailwindcss-tag-helpers/compare/v0.1.0...v0.2.0) - 2022-09-24
 
 > **Note**: This version drops support for .NET 5 which is no longer supported.

--- a/global.json
+++ b/global.json
@@ -9,6 +9,7 @@
     "test": "dotnet test",
     "test:31": "dotnet test --framework netcoreapp3.1",
     "test:6": "dotnet test --framework net6.0",
-    "pack": "dotnet pack --output \"./artifacts\""
+    "pack": "dotnet pack --output \"./artifacts\"",
+    "watch": "dotnet watch [env:DOTNET_WATCH_RESTART_ON_RUDE_EDIT=true] --verbose --project sample"
   }
 }

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LinkChildTagHelper.cs
+++ b/src/LinkChildTagHelper.cs
@@ -1,5 +1,7 @@
 namespace Tailwind.Css.TagHelpers;
 
+using System.Text.Encodings.Web;
+
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
 
@@ -7,8 +9,10 @@ using Microsoft.Extensions.Options;
 [HtmlTargetElement(ParentTag = "a", Attributes = DefaultClassAttributeName)]
 public class LinkChildTagHelper : LinkTagHelperBase
 {
-    public LinkChildTagHelper(IOptions<TagOptions> settings)
-        : base(settings)
+    public LinkChildTagHelper(
+        IOptions<TagOptions> settings,
+        HtmlEncoder htmlEncoder)
+        : base(settings, htmlEncoder)
     {
     }
 

--- a/src/LinkTagHelper.cs
+++ b/src/LinkTagHelper.cs
@@ -1,5 +1,7 @@
 namespace Tailwind.Css.TagHelpers;
 
+using System.Text.Encodings.Web;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
@@ -8,8 +10,10 @@ using Microsoft.Extensions.Options;
 [HtmlTargetElement("a", Attributes = DefaultClassAttributeName)]
 public class LinkTagHelper : LinkTagHelperBase
 {
-    public LinkTagHelper(IOptions<TagOptions> settings)
-        : base(settings)
+    public LinkTagHelper(
+        IOptions<TagOptions> settings,
+        HtmlEncoder htmlEncoder)
+        : base(settings, htmlEncoder)
     {
     }
 

--- a/src/LinkTagHelperBase.cs
+++ b/src/LinkTagHelperBase.cs
@@ -14,8 +14,6 @@ public abstract class LinkTagHelperBase : TagHelper
     protected const string CurrentClassAttributeName = "current-class";
     protected const string DefaultClassAttributeName = "default-class";
 
-    protected static readonly char[] SpaceChars = { '\u0020', '\u0009', '\u000A', '\u000C', '\u000D' };
-
     private readonly TagOptions _settings;
 
     protected LinkTagHelperBase(IOptions<TagOptions> settings)
@@ -35,16 +33,9 @@ public abstract class LinkTagHelperBase : TagHelper
     {
         if (output is null) throw new ArgumentNullException(nameof(output));
 
-        string[]? classList;
-
-        if (isMatch)
-        {
-            classList = CurrentClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
-        }
-        else
-        {
-            classList = DefaultClass?.Split(SpaceChars, StringSplitOptions.RemoveEmptyEntries);
-        }
+        var classList = isMatch
+            ? Utilities.SplitClassList(CurrentClass)
+            : Utilities.SplitClassList(DefaultClass);
 
         if (_settings.IncludeComments)
         {

--- a/src/LinkTagHelperBase.cs
+++ b/src/LinkTagHelperBase.cs
@@ -15,9 +15,15 @@ public abstract class LinkTagHelperBase : TagHelper
     protected const string DefaultClassAttributeName = "default-class";
 
     private readonly TagOptions _settings;
+    private readonly HtmlEncoder _htmlEncoder;
 
-    protected LinkTagHelperBase(IOptions<TagOptions> settings)
-        => _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    protected LinkTagHelperBase(
+        IOptions<TagOptions> settings,
+        HtmlEncoder htmlEncoder)
+    {
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+        _htmlEncoder = htmlEncoder ?? throw new ArgumentNullException(nameof(htmlEncoder));
+    }
 
     [HtmlAttributeName(CurrentClassAttributeName)]
     public string? CurrentClass { get; set; }
@@ -42,7 +48,7 @@ public abstract class LinkTagHelperBase : TagHelper
             output.PreElement.AppendHtmlLine("<!--");
 
             output.PreElement.Append("  Base: ");
-            output.PreElement.AppendLine(output.Attributes["class"]?.Value?.ToString() ?? "");
+            output.PreElement.AppendLine(Utilities.ExtractClassValue(output, _htmlEncoder));
 
             output.PreElement.Append("  Current: ");
             output.PreElement.AppendLine(CurrentClass ?? "");

--- a/src/LinkTagHelperBase.cs
+++ b/src/LinkTagHelperBase.cs
@@ -25,9 +25,15 @@ public abstract class LinkTagHelperBase : TagHelper
         _htmlEncoder = htmlEncoder ?? throw new ArgumentNullException(nameof(htmlEncoder));
     }
 
+    /// <summary>
+    /// The classes to apply when the link url matches the current url.
+    /// </summary>
     [HtmlAttributeName(CurrentClassAttributeName)]
     public string? CurrentClass { get; set; }
 
+    /// <summary>
+    /// The classes to apply when the link url doesn't match the current url.
+    /// </summary>
     [HtmlAttributeName(DefaultClassAttributeName)]
     public string? DefaultClass { get; set; }
 

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -1,0 +1,20 @@
+namespace Tailwind.Css.TagHelpers;
+
+using System;
+
+internal static class Utilities
+{
+    private static readonly char[] SpaceChars = { '\u0020', '\u0009', '\u000A', '\u000C', '\u000D' };
+
+    public static string[]? SplitClassList(string? classes)
+    {
+        if (string.IsNullOrWhiteSpace(classes))
+        {
+            return null;
+        }
+
+        return classes.Split(
+            SpaceChars,
+            StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/test/HtmlTestEncoder.cs
+++ b/test/HtmlTestEncoder.cs
@@ -1,0 +1,77 @@
+namespace Tailwind.Css.TagHelpers;
+
+using System.Text.Encodings.Web;
+
+// https://github.com/dotnet/aspnetcore/blob/d14dd282af26d6cab4617c7533a210ed550a9134/src/WebEncoders/src/Testing/HtmlTestEncoder.cs
+public sealed class HtmlTestEncoder : HtmlEncoder
+{
+    /// <inheritdoc />
+    public override int MaxOutputCharactersPerInputCharacter => 1;
+
+    /// <inheritdoc />
+    public override string Encode(string value)
+    {
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        if (value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return $"HtmlEncode[[{value}]]";
+    }
+
+    /// <inheritdoc />
+    public override void Encode(TextWriter output, char[] value, int startIndex, int characterCount)
+    {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        if (characterCount == 0)
+        {
+            return;
+        }
+
+        output.Write("HtmlEncode[[");
+        output.Write(value, startIndex, characterCount);
+        output.Write("]]");
+    }
+
+    /// <inheritdoc />
+    public override void Encode(TextWriter output, string value, int startIndex, int characterCount)
+    {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        if (characterCount == 0)
+        {
+            return;
+        }
+
+        output.Write("HtmlEncode[[");
+        output.Write(value.AsSpan(startIndex, characterCount));
+        output.Write("]]");
+    }
+
+    /// <inheritdoc />
+    public override bool WillEncode(int unicodeScalar) => false;
+
+    /// <inheritdoc />
+    public override unsafe int FindFirstCharacterToEncode(char* text, int textLength) => -1;
+
+    /// <inheritdoc />
+    public override unsafe bool TryEncodeUnicodeScalar(
+        int unicodeScalar,
+        char* buffer,
+        int bufferLength,
+        out int numberOfCharactersWritten)
+    {
+        if (buffer is null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        numberOfCharactersWritten = 0;
+        return false;
+    }
+}

--- a/test/LinkChildTagHelperTests.cs
+++ b/test/LinkChildTagHelperTests.cs
@@ -24,7 +24,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -60,7 +60,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
         AddLinkContext(context, isMatch);
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             ViewContext = MakeViewContext(),
         };
@@ -96,7 +96,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
         AddLinkContext(context, isMatch: false);
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -134,7 +134,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
         AddLinkContext(context, isMatch: true);
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -177,7 +177,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
             {
                 IncludeComments = false,
             });
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -216,7 +216,7 @@ public class LinkChildTagHelperTests : TagHelperTestBase
             {
                 IncludeComments = true,
             });
-        var helper = new LinkChildTagHelper(options)
+        var helper = new LinkChildTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",

--- a/test/LinkTagHelperTests.cs
+++ b/test/LinkTagHelperTests.cs
@@ -25,7 +25,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             ViewContext = MakeViewContext("/foo"),
         };
@@ -62,7 +62,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -100,7 +100,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -140,7 +140,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -180,7 +180,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             });
 
         var options = Options.Create(new TagOptions());
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -222,7 +222,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             {
                 IncludeComments = false,
             });
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",
@@ -259,7 +259,7 @@ public class LinkTagHelperTests : TagHelperTestBase
             {
                 IncludeComments = true,
             });
-        var helper = new LinkTagHelper(options)
+        var helper = new LinkTagHelper(options, new HtmlTestEncoder())
         {
             CurrentClass = "bg-orange no-underline",
             DefaultClass = "bg-white underline",

--- a/test/TailwindCssTagHelpersTests.csproj
+++ b/test/TailwindCssTagHelpersTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Tailwind.Css.TagHelpers</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If another tag helper modifies the `class` attribute before we try to read it then the attribute base type goes from `string` or `HtmlString` to `IHtmlContent`. Internally the `TagHelperOutputExtensions.AddClass()` and `TagHelperOutputExtensions.RemoveClass()` do [this exact type of check](https://github.com/dotnet/aspnetcore/blob/ce60f0d10c0adb79b2b824f5da05e41e1199f6cf/src/Mvc/Mvc.TagHelpers/src/TagHelperOutputExtensions.cs#L262-L280) when working with the class list.