### PR TITLE
Fix href attribute value extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug in `LinkTagHelper` that caused it to not match correctly when using `href="..."`
+
 ## [0.3.0](https://github.com/xt0rted/tailwindcss-tag-helpers/compare/v0.2.0...v0.3.0) - 2022-10-11
 
 ### Added

--- a/sample/Pages/Index.cshtml
+++ b/sample/Pages/Index.cshtml
@@ -63,7 +63,7 @@
   <div>
     <button
       type="submit"
-      class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      class="inline-flex items-center rounded-md border border-transparent bg-sky-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2"
     >
       Submit
     </button>

--- a/sample/Pages/Shared/_Layout.cshtml
+++ b/sample/Pages/Shared/_Layout.cshtml
@@ -28,6 +28,30 @@
           </a>
 
           <a
+            href="/privacy"
+            class="group flex items-center px-3 py-2 text-sm font-medium rounded-md"
+            default-class="text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+            current-class="bg-gray-200 text-gray-900"
+            aria-current-state="Page"
+          >
+            <heroicon-outline
+              icon="EyeOff"
+              class=" flex-shrink-0 -ml-1 mr-3 h-6 w-6"
+              default-class="text-gray-400 group-hover:text-gray-500"
+              current-class="text-gray-500"
+            />
+            <span class="truncate">Privacy - href</span>
+
+            <span
+              class="ml-auto inline-block py-0.5 px-3 text-xs rounded-full"
+              current-class="bg-gray-50"
+              default-class="bg-gray-200 text-gray-600 group-hover:bg-gray-200"
+            >
+              5
+            </span>
+          </a>
+
+          <a
             asp-area="" asp-page="/Privacy"
             class="group flex items-center px-3 py-2 text-sm font-medium rounded-md"
             default-class="text-gray-600 hover:bg-gray-50 hover:text-gray-900"
@@ -40,15 +64,7 @@
               default-class="text-gray-400 group-hover:text-gray-500"
               current-class="text-gray-500"
             />
-            <span class="truncate">Privacy</span>
-
-            <span
-              class="ml-auto inline-block py-0.5 px-3 text-xs rounded-full"
-              current-class="bg-gray-50"
-              default-class="bg-gray-200 text-gray-600 group-hover:bg-gray-200"
-            >
-              5
-            </span>
+            <span class="truncate">Privacy - asp-page</span>
           </a>
 
           <a

--- a/src/LinkTagHelper.cs
+++ b/src/LinkTagHelper.cs
@@ -25,7 +25,7 @@ public class LinkTagHelper : LinkTagHelperBase
         if (output is null) throw new ArgumentNullException(nameof(output));
 
         var currentPath = ViewContext.HttpContext.Request.Path;
-        var linkPath = new PathString(output.Attributes["href"]?.Value as string);
+        var linkPath = new PathString(output.Attributes.GetValue("href"));
         var isMatch = IsMatch(currentPath, linkPath);
 
         context.Items.Add(

--- a/src/LinkTagHelperBase.cs
+++ b/src/LinkTagHelperBase.cs
@@ -48,7 +48,7 @@ public abstract class LinkTagHelperBase : TagHelper
             output.PreElement.AppendHtmlLine("<!--");
 
             output.PreElement.Append("  Base: ");
-            output.PreElement.AppendLine(Utilities.ExtractClassValue(output));
+            output.PreElement.AppendLine(output.Attributes.GetValue("class"));
 
             output.PreElement.Append("  Current: ");
             output.PreElement.AppendLine(CurrentClass ?? "");

--- a/src/TagHelperAttributeListExtensions.cs
+++ b/src/TagHelperAttributeListExtensions.cs
@@ -1,0 +1,41 @@
+namespace Tailwind.Css.TagHelpers;
+
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+internal static class TagHelperAttributeListExtensions
+{
+    public static string GetValue(this TagHelperAttributeList attributes, string name)
+    {
+        if (!attributes.TryGetAttribute(name, out var classAttribute))
+        {
+            return "";
+        }
+
+        if (classAttribute?.Value is null)
+        {
+            return "";
+        }
+
+        var result = classAttribute.Value switch
+        {
+            string stringValue => stringValue,
+            HtmlString htmlString => htmlString.Value,
+            IHtmlContent htmlContent => ExtractHtmlContent(htmlContent),
+            _ => classAttribute.Value.ToString(),
+        };
+
+        return result ?? "";
+    }
+
+    private static string ExtractHtmlContent(IHtmlContent htmlContent)
+    {
+        using var stringWriter = new StringWriter();
+
+        htmlContent.WriteTo(stringWriter, HtmlEncoder.Default);
+
+        return stringWriter.ToString();
+    }
+}

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -1,10 +1,6 @@
 namespace Tailwind.Css.TagHelpers;
 
 using System;
-using System.Text.Encodings.Web;
-
-using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Razor.TagHelpers;
 
 internal static class Utilities
 {
@@ -17,27 +13,6 @@ internal static class Utilities
         '\u000D', // Carriage Return
     };
 
-    public static string ExtractClassValue(TagHelperOutput output)
-    {
-        if (!output.Attributes.TryGetAttribute("class", out var classAttribute))
-        {
-            return "";
-        }
-
-        if (classAttribute?.Value is null)
-        {
-            return "";
-        }
-
-        return classAttribute.Value switch
-        {
-            string stringValue => stringValue,
-            HtmlString htmlString => htmlString.Value,
-            IHtmlContent htmlContent => ExtractHtmlContent(htmlContent),
-            _ => classAttribute.Value.ToString() ?? "",
-        };
-    }
-
     public static string[]? SplitClassList(string? classes)
     {
         if (string.IsNullOrWhiteSpace(classes))
@@ -48,14 +23,5 @@ internal static class Utilities
         return classes.Split(
             SpaceChars,
             StringSplitOptions.RemoveEmptyEntries);
-    }
-
-    private static string ExtractHtmlContent(IHtmlContent htmlContent)
-    {
-        using var stringWriter = new StringWriter();
-
-        htmlContent.WriteTo(stringWriter, HtmlEncoder.Default);
-
-        return stringWriter.ToString();
     }
 }

--- a/src/ValidationStatusTagHelper.cs
+++ b/src/ValidationStatusTagHelper.cs
@@ -68,7 +68,7 @@ public class ValidationStatusTagHelper : TagHelper
             output.PreElement.AppendLine(For.Name);
 
             output.PreElement.Append("  Base: ");
-            output.PreElement.AppendLine(Utilities.ExtractClassValue(output));
+            output.PreElement.AppendLine(output.Attributes.GetValue("class"));
 
             output.PreElement.Append("  Default: ");
             output.PreElement.AppendLine(DefaultClass ?? "");


### PR DESCRIPTION
If you use the `asp-*` attributes so the built-in tag helper creates the `href` then everything was good, but if you set it directly then the attribute value ends up being of type `Htmlstring` so we didn't get the actual value. This updates that to use the same method as the `class` attribute.