### PR TITLE
Remove `coverlet.collector`

### DIFF
--- a/test/TailwindCssTagHelpersTests.csproj
+++ b/test/TailwindCssTagHelpersTests.csproj
@@ -28,10 +28,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This shouldn't be needed since moving to `GitHubActionsTestLogger`